### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 15
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 15
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
Modernizes some Github Actions. This fixes related deprecation warnings too.

`adopt` has become Temurin.

The Maven CI build seems broken and there's no run in this repository yet. Does this need some fixing?