### PR TITLE
c++ glue class generator

### DIFF
--- a/include/Application.h
+++ b/include/Application.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+/* Metadata about the application which saved the DAWPROJECT file. */
+struct Application
+{
+    std::string name; // Name of the application.
+    std::string version; // Version number of the application.
+};
+} // namespace DawProject
+

--- a/include/Arrangement.h
+++ b/include/Arrangement.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "common.h"
+#include "Lanes.h"
+#include "Markers.h"
+#include "Points.h"
+
+namespace DawProject
+{
+/* Represents the main Arrangement timeline of a DAW. */
+struct Arrangement
+{
+    /* Automation data for time-signature inside this Arrangement.
+     <pre><code>
+     &lt;Arrangement&gt;
+       &lt;TimeSignatureAutomation target=&quot;id-of-TimeSignatureParameter&quot; ... &gt;
+         &lt;TimeSignaturePoint time=&quot;0&quot; numerator=&quot;7&quot;, denominator=&quot;8&quot;/&gt;
+         &lt;TimeSignaturePoint time=&quot;21&quot; numerator=&quot;4&quot;, denominator=&quot;4&quot;/&gt;
+            ...
+       &lt;/TimeSignatureAutomation&gt;
+     &lt;/Arrangement&gt;
+     </code></pre> */
+    std::optional<Points> timeSignatureAutomation;
+    /* Automation data for tempo inside this Arrangement, which will define the conversion between seconds and beats
+     at the root level. */
+    std::optional<Points> tempoAutomation;
+    std::optional<Markers> markers; // Cue markers inside this arrangement
+    /* The lanes of this arrangement. Generally this would contain another Lanes timeline for (and scoped to) each
+     track which would then contain all Note, Audio, and Automation timelines. */
+    std::optional<Lanes> lanes;
+};
+} // namespace DawProject
+

--- a/include/AuPlugin.h
+++ b/include/AuPlugin.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common.h"
+#include "Plugin.h"
+
+namespace DawProject
+{
+struct AuPlugin
+    : public Plugin
+{
+};
+} // namespace DawProject
+

--- a/include/Audio.h
+++ b/include/Audio.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "common.h"
+#include "MediaFile.h"
+
+namespace DawProject
+{
+struct Audio
+    : public MediaFile
+{
+    int sampleRate;
+    int channels;
+    std::optional<std::string> algorithm;
+};
+} // namespace DawProject
+

--- a/include/AutomationTarget.h
+++ b/include/AutomationTarget.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+struct Parameter;
+
+struct AutomationTarget
+{
+    Parameter* parameter;
+    std::optional<ExpressionType> expression;
+    std::optional<int> channel;
+    std::optional<int> key;
+    std::optional<int> controller;
+};
+} // namespace DawProject
+

--- a/include/BoolParameter.h
+++ b/include/BoolParameter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+#include "Parameter.h"
+
+namespace DawProject
+{
+/* Represents a parameter which can provide a boolean (true/false) value and be used as an automation target. */
+struct BoolParameter
+    : public Parameter
+{
+    std::optional<bool> value; // Boolean value for this parameter.
+};
+} // namespace DawProject
+

--- a/include/BoolPoint.h
+++ b/include/BoolPoint.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Point.h"
+
+namespace DawProject
+{
+struct BoolPoint
+    : public Point
+{
+    bool value;
+};
+} // namespace DawProject
+

--- a/include/BuiltinDevice.h
+++ b/include/BuiltinDevice.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common.h"
+#include "Device.h"
+
+namespace DawProject
+{
+struct BuiltinDevice
+    : public Device
+{
+};
+} // namespace DawProject
+

--- a/include/Channel.h
+++ b/include/Channel.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "common.h"
+#include "Lane.h"
+#include "Send.h"
+#include "BoolParameter.h"
+#include "RealParameter.h"
+#include "Device.h"
+
+namespace DawProject
+{
+/* Represents a mixer channel. It provides the ability to route signals to other channels and can contain
+ Device/Plug-in for processing. */
+struct Channel
+    : public Lane
+{
+    std::optional<MixerRole> role; // Role of this channel in the mixer.
+    /* Number of audio-channels of this mixer channel. (1=mono, 2=stereo…) */
+    std::optional<int> audioChannels;
+    std::optional<RealParameter> volume; // Channel volume
+    std::optional<RealParameter> pan; // Channel pan/balance
+    std::optional<BoolParameter> mute; // Channel mute
+    std::optional<bool> solo; // Channel solo
+    Channel* destination; // Output channel routing
+    std::vector<Send> sends; // Send levels & destination
+    std::vector<Device> devices; // Devices & plug-ins of this channel
+};
+} // namespace DawProject
+

--- a/include/ClapPlugin.h
+++ b/include/ClapPlugin.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common.h"
+#include "Plugin.h"
+
+namespace DawProject
+{
+struct ClapPlugin
+    : public Plugin
+{
+};
+} // namespace DawProject
+

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "common.h"
+#include "Nameable.h"
+#include "Timeline.h"
+
+namespace DawProject
+{
+struct Clip
+    : public Nameable
+{
+    double time;
+    std::optional<double> duration;
+    std::optional<TimeUnit> contentTimeUnit;
+    std::optional<double> playStart;
+    std::optional<double> playStop;
+    std::optional<double> loopStart;
+    std::optional<double> loopEnd;
+    std::optional<TimeUnit> fadeTimeUnit;
+    std::optional<double> fadeInTime;
+    std::optional<double> fadeOutTime;
+    std::optional<Timeline> content;
+    Timeline* reference;
+};
+} // namespace DawProject
+

--- a/include/ClipSlot.h
+++ b/include/ClipSlot.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "Clip.h"
+
+namespace DawProject
+{
+struct ClipSlot
+    : public Timeline
+{
+    std::optional<bool> hasStop;
+    std::optional<Clip> clip;
+};
+} // namespace DawProject
+

--- a/include/Clips.h
+++ b/include/Clips.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "Clip.h"
+
+namespace DawProject
+{
+struct Clips
+    : public Timeline
+{
+    std::vector<Clip> clips;
+};
+} // namespace DawProject
+

--- a/include/Compressor.h
+++ b/include/Compressor.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "common.h"
+#include "BuiltinDevice.h"
+#include "BoolParameter.h"
+#include "RealParameter.h"
+
+namespace DawProject
+{
+struct Compressor
+    : public BuiltinDevice
+{
+    std::optional<RealParameter> threshold;
+    std::optional<RealParameter> ratio;
+    std::optional<RealParameter> attack;
+    std::optional<RealParameter> release;
+    std::optional<RealParameter> inputGain;
+    std::optional<RealParameter> outputGain;
+    std::optional<BoolParameter> autoMakeup;
+};
+} // namespace DawProject
+

--- a/include/Device.h
+++ b/include/Device.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "common.h"
+#include "FileReference.h"
+#include "Parameter.h"
+#include "BoolParameter.h"
+
+namespace DawProject
+{
+struct Device
+{
+    std::optional<BoolParameter> enabled;
+    DeviceRole deviceRole;
+    std::optional<bool> loaded;
+    std::string deviceName;
+    std::optional<std::string> deviceID;
+    std::optional<std::string> deviceVendor;
+    std::optional<FileReference> state;
+    std::vector<Parameter> automatedParameters;
+};
+} // namespace DawProject
+

--- a/include/EnumParameter.h
+++ b/include/EnumParameter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common.h"
+#include "Parameter.h"
+
+namespace DawProject
+{
+/* Represents an enumerated parameter which can provide a value and be used as an automation target. */
+struct EnumParameter
+    : public Parameter
+{
+    std::optional<int> value; // Index of the enum value.
+    /* Number of entries in enum value. value will be in the range [0 .. count-1]. */
+    int count;
+    std::vector<std::string> labels; // Labels of the individual enum values.
+};
+} // namespace DawProject
+

--- a/include/EnumPoint.h
+++ b/include/EnumPoint.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Point.h"
+
+namespace DawProject
+{
+struct EnumPoint
+    : public Point
+{
+    int value;
+};
+} // namespace DawProject
+

--- a/include/EqBand.h
+++ b/include/EqBand.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "common.h"
+#include "BoolParameter.h"
+#include "RealParameter.h"
+
+namespace DawProject
+{
+struct EqBand
+{
+    RealParameter freq;
+    std::optional<RealParameter> gain;
+    std::optional<RealParameter> Q;
+    std::optional<BoolParameter> enabled;
+    EqBandType type;
+    std::optional<int> order;
+};
+} // namespace DawProject
+

--- a/include/Equalizer.h
+++ b/include/Equalizer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common.h"
+#include "BuiltinDevice.h"
+#include "RealParameter.h"
+#include "EqBand.h"
+
+namespace DawProject
+{
+struct Equalizer
+    : public BuiltinDevice
+{
+    std::vector<EqBand> bands;
+    std::optional<RealParameter> inputGain;
+    std::optional<RealParameter> outputGain;
+};
+} // namespace DawProject
+

--- a/include/FileReference.h
+++ b/include/FileReference.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+/* References a file either within a DAWPROJECT container or on disk. */
+struct FileReference
+{
+    /* File path. either
+     <li>path within the container</li>
+     <li>relative to .dawproject file (when external = "true")</li>
+     <li>absolute path (when external = "true" and path starts with a slash or windows drive letter)</li> */
+    std::string path;
+    /* When true, the path is relative to the .dawproject file. Default value is false. */
+    std::optional<bool> external;
+};
+} // namespace DawProject
+

--- a/include/IntegerParameter.h
+++ b/include/IntegerParameter.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "common.h"
+#include "Parameter.h"
+
+namespace DawProject
+{
+/* Represents an enumerated parameter which can provide a value and be used as an automation target. */
+struct IntegerParameter
+    : public Parameter
+{
+    std::optional<int> value; // Integer value for this parameter.
+    std::optional<int> min; // Minimum value this parameter can have (inclusive).
+    std::optional<int> max; // Maximum value this parameter can have (inclusive).
+};
+} // namespace DawProject
+

--- a/include/IntegerPoint.h
+++ b/include/IntegerPoint.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Point.h"
+
+namespace DawProject
+{
+struct IntegerPoint
+    : public Point
+{
+    int value;
+};
+} // namespace DawProject
+

--- a/include/Lane.h
+++ b/include/Lane.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+struct Lane
+{
+};
+} // namespace DawProject
+

--- a/include/Lanes.h
+++ b/include/Lanes.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+
+namespace DawProject
+{
+struct Lanes
+    : public Timeline
+{
+    std::vector<Timeline> lanes;
+};
+} // namespace DawProject
+

--- a/include/Limiter.h
+++ b/include/Limiter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "common.h"
+#include "BuiltinDevice.h"
+#include "RealParameter.h"
+
+namespace DawProject
+{
+struct Limiter
+    : public BuiltinDevice
+{
+    std::optional<RealParameter> threshold;
+    std::optional<RealParameter> inputGain;
+    std::optional<RealParameter> outputGain;
+    std::optional<RealParameter> attack;
+    std::optional<RealParameter> release;
+};
+} // namespace DawProject
+

--- a/include/Marker.h
+++ b/include/Marker.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Nameable.h"
+
+namespace DawProject
+{
+struct Marker
+    : public Nameable
+{
+    double time;
+};
+} // namespace DawProject
+

--- a/include/Markers.h
+++ b/include/Markers.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "Marker.h"
+
+namespace DawProject
+{
+struct Markers
+    : public Timeline
+{
+    std::vector<Marker> markers;
+};
+} // namespace DawProject
+

--- a/include/MediaFile.h
+++ b/include/MediaFile.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "FileReference.h"
+
+namespace DawProject
+{
+struct MediaFile
+    : public Timeline
+{
+    FileReference file;
+    double duration;
+};
+} // namespace DawProject
+

--- a/include/MetaData.h
+++ b/include/MetaData.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+/* Metadata root element of the DAWPROJECT format. This is stored in the file metadata.xml file inside the container. */
+struct MetaData
+{
+    std::optional<std::string> title; // Title of the song/project.
+    std::optional<std::string> artist; // Recording Artist.
+    std::optional<std::string> album; // Album.
+    std::optional<std::string> originalArtist; // Original Artist.
+    std::optional<std::string> composer; // Composer.
+    std::optional<std::string> songwriter; // Songwriter.
+    std::optional<std::string> producer; // Producer.
+    std::optional<std::string> arranger; // Arranger.
+    std::optional<std::string> year; // Year this project/song was recorded.
+    std::optional<std::string> genre; // Genre/style
+    std::optional<std::string> copyright; // Copyright notice.
+    std::optional<std::string> website; // URL to website related to this project.
+    std::optional<std::string> comment; // General comment or description.
+};
+} // namespace DawProject
+

--- a/include/Nameable.h
+++ b/include/Nameable.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+struct Nameable
+{
+    std::optional<std::string> name; // Name/label of this object.
+    /* Color of this object in HTML-style format. (#rrggbb) */
+    std::optional<std::string> color;
+    std::optional<std::string> comment; // Comment/description of this object.
+};
+} // namespace DawProject
+

--- a/include/NoiseGate.h
+++ b/include/NoiseGate.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "common.h"
+#include "BuiltinDevice.h"
+#include "RealParameter.h"
+
+namespace DawProject
+{
+struct NoiseGate
+    : public BuiltinDevice
+{
+    std::optional<RealParameter> threshold;
+    std::optional<RealParameter> ratio;
+    std::optional<RealParameter> attack;
+    std::optional<RealParameter> release;
+    std::optional<RealParameter> range;
+};
+} // namespace DawProject
+

--- a/include/Note.h
+++ b/include/Note.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+
+namespace DawProject
+{
+struct Note
+{
+    double time;
+    double duration;
+    std::optional<int> channel;
+    int key;
+    std::optional<double> velocity;
+    std::optional<double> releaseVelocity;
+    std::optional<Timeline> content;
+};
+} // namespace DawProject
+

--- a/include/Notes.h
+++ b/include/Notes.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "Note.h"
+
+namespace DawProject
+{
+struct Notes
+    : public Timeline
+{
+    std::vector<Note> notes;
+};
+} // namespace DawProject
+

--- a/include/Parameter.h
+++ b/include/Parameter.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+/* Represents a parameter which can provide a value and be used as an automation target. */
+struct Parameter
+{
+    /* Parameter ID as used by VST2 (index), VST3(ParamID) */
+    std::optional<int> parameterID;
+};
+} // namespace DawProject
+

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Device.h"
+
+namespace DawProject
+{
+struct Plugin
+    : public Device
+{
+    std::optional<std::string> pluginVersion;
+};
+} // namespace DawProject
+

--- a/include/Point.h
+++ b/include/Point.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+struct Point
+{
+    double time;
+};
+} // namespace DawProject
+

--- a/include/Points.h
+++ b/include/Points.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "AutomationTarget.h"
+#include "Point.h"
+
+namespace DawProject
+{
+struct Points
+    : public Timeline
+{
+    AutomationTarget target;
+    std::vector<Point> points;
+    std::optional<Unit> unit;
+};
+} // namespace DawProject
+

--- a/include/Project.h
+++ b/include/Project.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "common.h"
+#include "Application.h"
+#include "Transport.h"
+#include "Lane.h"
+#include "Arrangement.h"
+#include "Scene.h"
+
+namespace DawProject
+{
+/* The main root element of the DAWPROJECT format. This is stored in the file project.xml file inside the container. */
+struct Project
+{
+    /* Version of DAWPROJECT format this file was saved as. */
+    std::string version;
+    /* Metadata (name/version) about the application that saved this file. */
+    Application application;
+    /* Transport element containing playback parameters such as Tempo and Time-signature. */
+    std::optional<Transport> transport;
+    std::vector<Lane> structure; // Track/Channel structure of this file.
+    std::optional<Arrangement> arrangement; // The main Arrangement timeline of this file.
+    std::vector<Scene> scenes; // Clip Launcher scenes of this file.
+};
+} // namespace DawProject
+

--- a/include/RealParameter.h
+++ b/include/RealParameter.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "common.h"
+#include "Parameter.h"
+
+namespace DawProject
+{
+/* Represents a real valued (double) parameter which can provide a value and be used as an automation target. */
+struct RealParameter
+    : public Parameter
+{
+    /* Real (double) value for this parameter.
+     <p>When serializing value to text for XML, infinite values are allowed and should be represented as inf and -inf. </p> */
+    std::optional<double> value;
+    /* Unit in which value, min and max are defined.
+     <p>Using this rather than normalized value ranges allows transfer of parameter values and automation data.</p> */
+    Unit unit;
+    std::optional<double> min; // Minimum value this parameter can have (inclusive).
+    std::optional<double> max; // Maximum value this parameter can have (inclusive).
+};
+} // namespace DawProject
+

--- a/include/RealPoint.h
+++ b/include/RealPoint.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+#include "Point.h"
+
+namespace DawProject
+{
+struct RealPoint
+    : public Point
+{
+    double value;
+    std::optional<Interpolation> interpolation;
+};
+} // namespace DawProject
+

--- a/include/Scene.h
+++ b/include/Scene.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+
+namespace DawProject
+{
+/* Represents a clip launcher Scene of a DAW. */
+struct Scene
+{
+    /* Content timeline of this scene, will typically be structured like this:
+     <pre><code>
+     &lt;Scene&gt;
+       &lt;Lanes&gt;
+         &lt;ClipSlot track=&quot;...&quot;&gt;
+            &lt;Clip&gt;
+               ...
+            &lt;/Clip&gt;
+         &lt;/ClipSlot&gt;
+          ...
+       &lt;/Lanes&gt;
+     &lt;/Scene&gt;
+     </code></pre> */
+    Timeline content;
+};
+} // namespace DawProject
+

--- a/include/Send.h
+++ b/include/Send.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "common.h"
+#include "RealParameter.h"
+
+namespace DawProject
+{
+struct Channel;
+
+/* A single send of a mixer channel. */
+struct Send
+{
+    RealParameter volume; // Send level.
+    std::optional<RealParameter> pan; // Send pan/balance.
+    std::optional<SendType> type; // Send type.
+    Channel* destination; // Send destination.
+};
+} // namespace DawProject
+

--- a/include/TimeSignatureParameter.h
+++ b/include/TimeSignatureParameter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common.h"
+#include "Parameter.h"
+
+namespace DawProject
+{
+/* Represents a (the) time-signature parameter which can provide a value and be used as an automation target. */
+struct TimeSignatureParameter
+    : public Parameter
+{
+    /* Numerator of the time-signature. (3/4 &rarr; 3, 4/4 &rarr; 4) */
+    int numerator;
+    /* Denominator of the time-signature. (3/4 &rarr; 4, 7/8 &rarr; 8) */
+    int denominator;
+};
+} // namespace DawProject
+

--- a/include/TimeSignaturePoint.h
+++ b/include/TimeSignaturePoint.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+#include "Point.h"
+
+namespace DawProject
+{
+struct TimeSignaturePoint
+    : public Point
+{
+    int numerator;
+    int denominator;
+};
+} // namespace DawProject
+

--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+struct Track;
+
+struct Timeline
+{
+    Track* track;
+    std::optional<TimeUnit> timeUnit;
+};
+} // namespace DawProject
+

--- a/include/Track.h
+++ b/include/Track.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "common.h"
+#include "Lane.h"
+#include "Channel.h"
+
+namespace DawProject
+{
+/* Represents a sequencer track. */
+struct Track
+    : public Lane
+{
+    /* Role of this track in timelines & arranger. Can be multiple (comma-separated). */
+    std::vector<ContentType> contentType;
+    std::optional<bool> loaded; // If this track is loaded/active of not.
+    std::optional<Channel> channel; // Mixer channel used for the output of this track.
+    /* Child tracks, typically used to represent group/folder tracks with contentType="tracks". */
+    std::vector<Track> tracks;
+};
+} // namespace DawProject
+

--- a/include/Transport.h
+++ b/include/Transport.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "common.h"
+#include "RealParameter.h"
+#include "TimeSignatureParameter.h"
+
+namespace DawProject
+{
+/* Transport element containing playback parameters such as Tempo and Time-signature. */
+struct Transport
+{
+    /* Tempo parameter for setting and/or automating the tempo. */
+    std::optional<RealParameter> tempo;
+    std::optional<TimeSignatureParameter> timeSignature; // Time-signature parameter.
+};
+} // namespace DawProject
+

--- a/include/Video.h
+++ b/include/Video.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "common.h"
+#include "MediaFile.h"
+
+namespace DawProject
+{
+struct Video
+    : public MediaFile
+{
+    std::optional<int> sampleRate;
+    std::optional<int> channels;
+    std::optional<std::string> algorithm;
+};
+} // namespace DawProject
+

--- a/include/Vst2Plugin.h
+++ b/include/Vst2Plugin.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common.h"
+#include "Plugin.h"
+
+namespace DawProject
+{
+struct Vst2Plugin
+    : public Plugin
+{
+};
+} // namespace DawProject
+

--- a/include/Vst3Plugin.h
+++ b/include/Vst3Plugin.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common.h"
+#include "Plugin.h"
+
+namespace DawProject
+{
+struct Vst3Plugin
+    : public Plugin
+{
+};
+} // namespace DawProject
+

--- a/include/Warp.h
+++ b/include/Warp.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "common.h"
+
+namespace DawProject
+{
+struct Warp
+{
+    double time;
+    double contentTime;
+};
+} // namespace DawProject
+

--- a/include/Warps.h
+++ b/include/Warps.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "common.h"
+#include "Timeline.h"
+#include "Warp.h"
+
+namespace DawProject
+{
+struct Warps
+    : public Timeline
+{
+    std::vector<Warp> events;
+    Timeline content;
+    TimeUnit contentTimeUnit;
+};
+} // namespace DawProject
+

--- a/include/common.h
+++ b/include/common.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace DawProject
+{
+//constants
+static constexpr std::string_view CURRENT_VERSION = "1.0";
+
+//enums
+enum TimeUnit: int
+{
+    TIME_UNIT_BEATS = 0,
+    TIME_UNIT_SECONDS = 1,
+};
+
+enum Interpolation: int
+{
+    INTERPOLATION_HOLD = 0,
+    INTERPOLATION_LINEAR = 1,
+};
+
+enum Unit: int
+{
+    UNIT_LINEAR = 0,
+    UNIT_NORMALIZED = 1,
+    UNIT_PERCENT = 2,
+    UNIT_DECIBEL = 3,
+    UNIT_HERTZ = 4,
+    UNIT_SEMITONES = 5,
+    UNIT_SECONDS = 6,
+    UNIT_BEATS = 7,
+    UNIT_BPM = 8,
+};
+
+enum SendType: int
+{
+    SEND_TYPE_PRE = 0,
+    SEND_TYPE_POST = 1,
+};
+
+enum MixerRole: int
+{
+    MIXER_ROLE_REGULAR = 0,
+    MIXER_ROLE_MASTER = 1,
+    MIXER_ROLE_EFFECTTRACK = 2,
+    MIXER_ROLE_SUBMIX = 3,
+    MIXER_ROLE_VCA = 4,
+};
+
+enum DeviceRole: int
+{
+    DEVICE_ROLE_INSTRUMENT = 0,
+    DEVICE_ROLE_NOTEFX = 1,
+    DEVICE_ROLE_AUDIOFX = 2,
+    DEVICE_ROLE_ANALYZER = 3,
+};
+
+enum ContentType: int
+{
+    CONTENT_TYPE_AUDIO = 0,
+    CONTENT_TYPE_AUTOMATION = 1,
+    CONTENT_TYPE_NOTES = 2,
+    CONTENT_TYPE_VIDEO = 3,
+    CONTENT_TYPE_MARKERS = 4,
+    CONTENT_TYPE_TRACKS = 5,
+};
+
+enum ExpressionType: int
+{
+    EXPRESSION_TYPE_GAIN = 0,
+    EXPRESSION_TYPE_PAN = 1,
+    EXPRESSION_TYPE_TRANSPOSE = 2,
+    EXPRESSION_TYPE_TIMBRE = 3,
+    EXPRESSION_TYPE_FORMANT = 4,
+    EXPRESSION_TYPE_PRESSURE = 5,
+    EXPRESSION_TYPE_CHANNELCONTROLLER = 6,
+    EXPRESSION_TYPE_CHANNELPRESSURE = 7,
+    EXPRESSION_TYPE_POLYPRESSURE = 8,
+    EXPRESSION_TYPE_PITCHBEND = 9,
+    EXPRESSION_TYPE_PROGRAMCHANGE = 10,
+};
+
+enum EqBandType: int
+{
+    EQ_BAND_TYPE_HIGHPASS = 0,
+    EQ_BAND_TYPE_LOWPASS = 1,
+    EQ_BAND_TYPE_BANDPASS = 2,
+    EQ_BAND_TYPE_HIGHSHELF = 3,
+    EQ_BAND_TYPE_LOWSHELF = 4,
+    EQ_BAND_TYPE_BELL = 5,
+    EQ_BAND_TYPE_NOTCH = 6,
+};
+} // namespace DawProject
+

--- a/src/test/java/com/bitwig/dawproject/GenerateCppTest.java
+++ b/src/test/java/com/bitwig/dawproject/GenerateCppTest.java
@@ -1,0 +1,391 @@
+package com.bitwig.dawproject;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import com.bitwig.dawproject.device.AuPlugin;
+import com.bitwig.dawproject.device.BuiltinDevice;
+import com.bitwig.dawproject.device.ClapPlugin;
+import com.bitwig.dawproject.device.Compressor;
+import com.bitwig.dawproject.device.Device;
+import com.bitwig.dawproject.device.DeviceRole;
+import com.bitwig.dawproject.device.EqBand;
+import com.bitwig.dawproject.device.EqBandType;
+import com.bitwig.dawproject.device.Equalizer;
+import com.bitwig.dawproject.device.Limiter;
+import com.bitwig.dawproject.device.NoiseGate;
+import com.bitwig.dawproject.device.Plugin;
+import com.bitwig.dawproject.device.Vst2Plugin;
+import com.bitwig.dawproject.device.Vst3Plugin;
+import com.bitwig.dawproject.timeline.Audio;
+import com.bitwig.dawproject.timeline.AutomationTarget;
+import com.bitwig.dawproject.timeline.BoolPoint;
+import com.bitwig.dawproject.timeline.Clip;
+import com.bitwig.dawproject.timeline.ClipSlot;
+import com.bitwig.dawproject.timeline.Clips;
+import com.bitwig.dawproject.timeline.EnumPoint;
+import com.bitwig.dawproject.timeline.IntegerPoint;
+import com.bitwig.dawproject.timeline.Lanes;
+import com.bitwig.dawproject.timeline.Marker;
+import com.bitwig.dawproject.timeline.Markers;
+import com.bitwig.dawproject.timeline.MediaFile;
+import com.bitwig.dawproject.timeline.Note;
+import com.bitwig.dawproject.timeline.Notes;
+import com.bitwig.dawproject.timeline.Point;
+import com.bitwig.dawproject.timeline.Points;
+import com.bitwig.dawproject.timeline.RealPoint;
+import com.bitwig.dawproject.timeline.TimeSignaturePoint;
+import com.bitwig.dawproject.timeline.TimeUnit;
+import com.bitwig.dawproject.timeline.Timeline;
+import com.bitwig.dawproject.timeline.Video;
+import com.bitwig.dawproject.timeline.Warp;
+import com.bitwig.dawproject.timeline.Warps;
+import com.github.therapi.runtimejavadoc.BaseJavadoc;
+import com.github.therapi.runtimejavadoc.CommentFormatter;
+import com.github.therapi.runtimejavadoc.FieldJavadoc;
+import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementRef;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlIDREF;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GenerateCppTest
+{
+   private final static Class[] classes = new Class[] {
+      // Root
+      Project.class, MetaData.class,
+      // Other
+      Application.class, FileReference.class, Transport.class,
+      // Mixer
+      Lane.class, Track.class, Channel.class, Send.class,
+      // Timeline
+      Arrangement.class,
+      Scene.class,
+      ClipSlot.class,
+      Timeline.class,
+      Lanes.class,
+      Clips.class,
+      Clip.class,
+      Notes.class,
+      Note.class,
+      Audio.class,
+      Video.class,
+      Warps.class,
+      Warp.class,
+      Markers.class,
+      Marker.class,
+      // Parameters
+      Parameter.class,
+      BoolParameter.class,
+      EnumParameter.class,
+      IntegerParameter.class,
+      RealParameter.class,
+      TimeSignatureParameter.class,
+      // Automation
+      Points.class,
+      AutomationTarget.class,
+      Point.class,
+      RealPoint.class,
+      BoolPoint.class,
+      EnumPoint.class,
+      IntegerPoint.class,
+      TimeSignaturePoint.class,
+      // Device
+      Device.class, AuPlugin.class, ClapPlugin.class, Plugin.class, Vst2Plugin.class, Vst3Plugin.class,
+      BuiltinDevice.class,
+      Compressor.class,
+      Equalizer.class, EqBand.class,
+      Limiter.class,
+      NoiseGate.class,
+      // Abstract
+      Nameable.class,/* Referenceable.class,*/ MediaFile.class,
+   };
+
+   private final static Enum<?>[][] enums = new Enum[][] {
+      TimeUnit.values(),
+      Interpolation.values(),
+      Unit.values(),
+      SendType.values(),
+      MixerRole.values(),
+      DeviceRole.values(),
+      ContentType.values(),
+      ExpressionType.values(),
+      EqBandType.values(),
+   };
+
+   @Test
+   public void generateCppFile() throws IOException
+   {
+      final var includePath = Paths.get("include");
+      if (!Files.exists(includePath))
+         Files.createDirectory(includePath);
+      Assert.assertTrue(Files.isDirectory(includePath));
+      final var targetPathString = includePath.toAbsolutePath() + "/";
+
+      final var sb = new StringBuilder();
+
+      // generate common header
+      sb.append("#pragma once\n\n");
+      sb.append("#include <optional>\n");
+      sb.append("#include <string>\n");
+      sb.append("#include <vector>\n");
+      sb.append("\n");
+      sb.append("namespace DawProject\n{\n");
+      sb.append("//constants\n");
+      sb.append("static constexpr std::string_view CURRENT_VERSION = \"" + Project.CURRENT_VERSION + "\";\n\n");
+      sb.append("//enums\n");
+      generateEnums(sb);
+      sb.append("} // namespace DawProject\n");
+      final var enumHeaderFile = new File(targetPathString + "common.h");
+      Files.write(enumHeaderFile.toPath(), Collections.singleton(sb.toString()), StandardCharsets.UTF_8);
+      Assert.assertTrue(enumHeaderFile.exists());      
+
+      // generate class files
+      for (final var cls : classes)
+      {
+         sb.setLength(0);
+         sb.append("#pragma once\n\n");
+         sb.append("#include \"common.h\"\n");
+         final var superclass = cls.getSuperclass();
+         if(isRelevantSuperClass(superclass))
+            sb.append("#include \"" + superclass.getSimpleName() + ".h\"\n");
+         var forwardDeclaredClassNames = new ArrayList<String>();
+         for (final var otherClass : classes)
+         {
+            if(otherClass == cls)
+               continue; // don't include itself
+            if(otherClass == superclass)
+               continue; // already handled above
+            for(final var field : cls.getDeclaredFields())
+            {
+               Class<?> fieldType = field.getType();
+               if (fieldType.isArray())
+                  fieldType = fieldType.getComponentType();
+               else if(fieldType == List.class)
+                  fieldType = getListGenericType(field);
+               if(otherClass == fieldType)
+               {
+                  if(isIdRef(field))
+                  {
+                     forwardDeclaredClassNames.add(otherClass.getSimpleName());
+                     continue;
+                  }
+                  else
+                     sb.append("#include \"" + otherClass.getSimpleName() + ".h\"\n");
+                  break;
+               }
+            }
+         }
+         sb.append("\n");
+         sb.append("namespace DawProject\n{\n");
+         for(final var className : forwardDeclaredClassNames)
+         {
+            sb.append("struct " + className + ";\n");
+         }
+         if(!forwardDeclaredClassNames.isEmpty())
+            sb.append("\n");
+         generateClass(sb, cls);
+         sb.append("} // namespace DawProject\n");
+         final var classHeaderFile = new File(targetPathString + cls.getSimpleName() + ".h");
+         Files.write(classHeaderFile.toPath(), Collections.singleton(sb.toString()), StandardCharsets.UTF_8);
+         Assert.assertTrue(classHeaderFile.exists());
+      }
+   }
+
+   private boolean isRelevantSuperClass(Class superclass)
+   {
+      return superclass != Object.class && superclass != Referenceable.class;
+   }
+
+   private void generateEnums(StringBuilder sb)
+   {
+      boolean isFirst = true;
+      for(final var values : enums)
+      {
+         if(isFirst)
+            isFirst = false;
+         else
+            sb.append("\n");
+         generateEnum(sb, values);
+      }
+   }
+
+   private void generateEnumEntryName(StringBuilder sb, String enumName, String entryName)
+   {
+      for (int i = 0; i < enumName.length(); i++)
+      {
+         final var c = enumName.charAt(i);
+         if(Character.isUpperCase(c) && i != 0)
+         {
+            sb.append("_");
+         }
+         sb.append(Character.toString(c).toUpperCase());
+      }
+
+      sb.append("_");
+      sb.append(entryName.toUpperCase());
+   }
+
+   private void generateEnum(final StringBuilder sb, final Enum[] values)
+   {
+      final var name = values[0].getClass().getSimpleName();
+      sb.append("enum " + name + ": int\n{\n");
+      for (Enum value : values)
+      {
+         sb.append("    ");
+         generateEnumEntryName(sb, name, value.name());
+         sb.append(" = ");
+         sb.append(value.ordinal());
+         sb.append(",\n");
+      }
+
+      sb.append("};\n");
+   }
+
+   private void appendJavaDoc(final StringBuilder sb, final BaseJavadoc javadoc, int indentation)
+   {
+      if (javadoc.isEmpty())
+         return;
+      final var comment = formatter.format(javadoc.getComment());
+      if (comment.isEmpty())
+         return;
+      final var indent = " ".repeat(indentation);
+      sb.append(indent + "/* ");
+      sb.append(comment.replace("\n", "\n" + indent));
+      sb.append(" */\n");
+   }
+
+   private void generateClass(final StringBuilder sb, final Class<?> cls)
+   {
+      appendJavaDoc(sb, RuntimeJavadoc.getJavadoc(cls), 0);
+
+      final var name = cls.getSimpleName();
+      sb.append("struct " + name + "\n");
+
+      var superClass = cls.getSuperclass();
+      if (isRelevantSuperClass(superClass))
+         sb.append("    : public " + superClass.getSimpleName() + "\n");
+
+      sb.append("{\n");
+
+      for (final var field : cls.getDeclaredFields())
+      {
+         if(Modifier.isStatic(field.getModifiers()))
+            continue;
+         final var fieldJavadoc = RuntimeJavadoc.getJavadoc(field);
+         generateStructField(sb, field, fieldJavadoc);
+      }
+
+      sb.append("};\n");
+   }
+
+   private void generateStructField(final StringBuilder sb, final Field field, final FieldJavadoc fieldJavadoc)
+   {
+      final String commentText = fieldJavadoc != null && !fieldJavadoc.isEmpty() ? fieldJavadoc.getComment().toString() : "";
+
+      final var isCommentLong = commentText.length() > 50 || commentText.contains("\n");
+
+      if (isCommentLong)
+         appendJavaDoc(sb, fieldJavadoc, 4);
+
+      var typeString = getTypeString(field);
+      if(isIdRef(field))
+         typeString = typeString + "*";
+      else if(!isRequired(field) && !isListOrArray(field))
+         typeString = "std::optional<" + typeString + ">";
+      sb.append("    ");
+      sb.append(typeString + " " + getFieldName(field));
+      sb.append(";");
+
+      if (!isCommentLong && !commentText.isEmpty())
+      {
+         sb.append(" // ");
+         sb.append(commentText);
+      }
+      sb.append("\n");
+   }
+
+   private boolean isListOrArray(final Field field)
+   {
+      final var type = field.getType();
+      return type.isArray() || type == List.class;
+   }
+
+   private boolean isIdRef(final Field field)
+   {
+      return field.getAnnotation(XmlIDREF.class) != null;
+   }
+
+   private boolean isRequired(final Field field)
+   {
+      for (final var annotation : field.getAnnotations())
+      {
+         if (annotation instanceof XmlElementWrapper e && e.required())
+            return true;
+         else if (annotation instanceof XmlElement e && e.required())
+            return true;
+         else if (annotation instanceof XmlElementRef e && e.required())
+            return true;
+         else if (annotation instanceof XmlAttribute e && e.required())
+            return true;
+      }
+      return false;
+   }
+
+   private String getTypeString(final Class<?> type)
+   {
+      if (type == String.class)
+         return "std::string";
+      if (type == Integer.class)
+         return "int";
+      if (type == Double.class)
+         return "double";
+      if (type == Boolean.class)
+         return "bool";
+      if (type == double.class)
+         return "double";
+      if (type == int.class)
+         return "int";
+      if (type.isArray())
+         return "std::vector<" + getTypeString(type.getComponentType()) + ">"; // recursive call for getTypeString!
+      return type.getSimpleName();
+   }
+
+   private String getTypeString(final Field field)
+   {
+      final Class<?> type1 = field.getType();
+      if (type1 == List.class)
+         return "std::vector<" + getListGenericType(field).getSimpleName() + ">";
+
+      return getTypeString(field.getType());
+   }
+
+   private static String getFieldName(final Field field)
+   {
+      return field.getName();
+   }
+
+   Class getListGenericType(final Field field)
+   {
+      if (field.getGenericType() instanceof ParameterizedType pt && pt.getActualTypeArguments().length == 1)
+      {
+         final var listType = pt.getActualTypeArguments()[0];
+         if (listType instanceof Class cls)
+            return cls;
+      }
+      return null;
+   }
+
+   private static final CommentFormatter formatter = new CommentFormatter();
+}


### PR DESCRIPTION
This is an initial draft for a c++ glue class generator.

I tested including it into a test c++ project and using some of the classes and it compiled.

I have not much time to continue this but wanted to propose as others hopefully might want to jump on board or use it as a bad example ;)

### Decisions
(please change if you know it better)
- I put everything into separate headers to better be able to handle include and forward declaration dependencies.
- I left out the Referenceable class completely and used raw pointers for the references instead. I think the ID assigment better should happen during XML creation/parsing.

### Known issues
- comments are not transferred correctly, e.g. in Arrangement.h you can clearly see the issues. Also I think some comments get lost completely
- enums probably rather should be enum classes
- maybe the usage of raw pointers for the references is not the optimal solution (?)
- ...